### PR TITLE
chunk size hard coded to 100

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ async function* processInChunks<T, M extends keyof T, P extends keyof T>(
 async function embedAndUpsert(dataFrame: dfd.DataFrame, chunkSize: number) {
   const chunkGenerator = processInChunks<ArticleRecord, 'section' | 'url' | 'title' | 'publication' | 'author' | 'article', 'article'>(
     dataFrame,
-    100,
+    chunkSize,
     ['section', 'url', 'title', 'publication', 'author', 'article'],
     'article'
   );


### PR DESCRIPTION
## Problem

The `chunkSize` is passed as a param but is then hard coded as `100` 

## Solution

Used the `chunkSize` param and remove ed the hard coded `100`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Run the example and the progress bar displays the correct value.
